### PR TITLE
Remove URL key from desktop file

### DIFF
--- a/gui/scram-gui.desktop
+++ b/gui/scram-gui.desktop
@@ -8,5 +8,4 @@ Terminal=false
 Type=Application
 MimeType=text/xml
 Categories=Science;Engineering;
-URL=https://scram-pra.org
 Keywords=science;education;engineering;


### PR DESCRIPTION
URL key can present only if entry is Link type but not Application.
https://standards.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html#recognized-keys