### PR TITLE
GUI: Allow panning the active window using the left mouse button (issue #277)

### DIFF
--- a/gui/zoomableview.cpp
+++ b/gui/zoomableview.cpp
@@ -63,4 +63,18 @@ void ZoomableView::wheelEvent(QWheelEvent *event)
     }
 }
 
+void ZoomableView::mousePressEvent(QMouseEvent *event)
+{
+    if (event->button() == Qt::LeftButton) {
+        this->setDragMode(QGraphicsView::ScrollHandDrag);
+    }
+    QGraphicsView::mousePressEvent(event);
+}
+
+void ZoomableView::mouseReleaseEvent(QMouseEvent *event)
+{
+    this->setDragMode(QGraphicsView::NoDrag);
+    QGraphicsView::mouseReleaseEvent(event);
+}
+
 } // namespace scram::gui

--- a/gui/zoomableview.h
+++ b/gui/zoomableview.h
@@ -21,8 +21,8 @@
 #pragma once
 
 #include <QGraphicsView>
-#include <QWheelEvent>
 #include <QMouseEvent>
+#include <QWheelEvent>
 
 namespace scram::gui {
 

--- a/gui/zoomableview.h
+++ b/gui/zoomableview.h
@@ -59,9 +59,11 @@ protected:
     /// Provides support for zoom-in/out with a mouse while holding Control key.
     void wheelEvent(QWheelEvent *event) override;
 
-    /// Provides support for starting the panning of the window using the left mouse button
+    /// Provides support for starting the panning of the window using the left
+    /// mouse button
     void mousePressEvent(QMouseEvent *event) override;
-    /// Provides support for stopping the panning of the window using the left mouse button
+    /// Provides support for stopping the panning of the window using the left
+    /// mouse button
     void mouseReleaseEvent(QMouseEvent *event) override;
 
 private:

--- a/gui/zoomableview.h
+++ b/gui/zoomableview.h
@@ -22,6 +22,7 @@
 
 #include <QGraphicsView>
 #include <QWheelEvent>
+#include <QMouseEvent>
 
 namespace scram::gui {
 
@@ -57,6 +58,10 @@ public slots:
 protected:
     /// Provides support for zoom-in/out with a mouse while holding Control key.
     void wheelEvent(QWheelEvent *event) override;
+
+    /// Provides support for panning the window using the left mouse button
+    void mousePressEvent(QMouseEvent *event) override;
+    void mouseReleaseEvent(QMouseEvent *event) override;
 
 private:
     static const int m_minZoomLevel = 10; ///< The minimum allowed zoom level.

--- a/gui/zoomableview.h
+++ b/gui/zoomableview.h
@@ -59,8 +59,9 @@ protected:
     /// Provides support for zoom-in/out with a mouse while holding Control key.
     void wheelEvent(QWheelEvent *event) override;
 
-    /// Provides support for panning the window using the left mouse button
+    /// Provides support for starting the panning of the window using the left mouse button
     void mousePressEvent(QMouseEvent *event) override;
+    /// Provides support for stopping the panning of the window using the left mouse button
     void mouseReleaseEvent(QMouseEvent *event) override;
 
 private:


### PR DESCRIPTION
As discussed in #277 : This PR allows panning the view using the mouse.

In the end, it is done using the left mouse button (iso the middle mouse one) for the sake of simplicity (this is provided out of the box with QGraphicsView and the middle mouse button implementations I found were a bit hacky)

There seems to be no conflict with the existing mouse pressing functionality (clicking the FTA elements). The view cannot be dragged if the user clicked on one of the FTA elements, but I didn't consider this an issue.