### PR TITLE
Update error.h to work with current Boost

### DIFF
--- a/src/error.h
+++ b/src/error.h
@@ -41,9 +41,9 @@
 /// the resultant exception type to conform to boost::exception.
 ///
 /// @param[in] err  The error type deriving from boost::exception.
-#define SCRAM_THROW(err)                                                       \
-  throw err << ::boost::throw_function(BOOST_THROW_EXCEPTION_CURRENT_FUNCTION) \
-            << ::boost::throw_file(FILE_REL_PATH)                              \
+#define SCRAM_THROW(err)                                       \
+  throw err << ::boost::throw_function(BOOST_CURRENT_FUNCTION) \
+            << ::boost::throw_file(FILE_REL_PATH)              \
             << ::boost::throw_line(__LINE__)
 
 namespace scram {


### PR DESCRIPTION
BOOST_THROW_EXCEPTION_CURRENT_FUNCTION was an extension point for the boost exception mechanism, but this has since been removed.  However, this by default resolved to BOOST_CURRENT_FUNCTION, a public API point that still exists.